### PR TITLE
fix: write deposit PDFs to collection root instead of pdsc_admin/

### DIFF
--- a/src/common/handle-special.ts
+++ b/src/common/handle-special.ts
@@ -48,7 +48,7 @@ export const handler: Handler = Sentry.wrapHandler(async (event: Event) => {
 
   await download(bucketName, objectKey, 'deposit.pdf');
 
-  const dst = `${collectionIdentifier}/pdsc_admin/${collectionIdentifier}-deposit.pdf`;
+  const dst = `${collectionIdentifier}/${collectionIdentifier}-deposit.pdf`;
 
   await upload(src, destBucket, dst, 'application/pdf');
 


### PR DESCRIPTION
Part of nabu wayfinder map [Wayfinder: eliminate pdsc_admin/ from the catalog bucket](https://github.com/paradisec-archive/nabu/issues/1163), ticket [Paragest: write deposit PDFs to collection root](https://github.com/paradisec-archive/nabu/issues/1167).

Deposit forms now upload to `<coll>/<coll>-deposit.pdf` in `nabu-catalog-<env>` instead of `<coll>/pdsc_admin/<coll>-deposit.pdf`.

**Do not merge/deploy independently** — this must go out in step with nabu's matching key-builder change, since nabu serves the deposit PDF from the key its own builder produces. Cutover sequencing is handled by the map's migration-runbook ticket ([#1168](https://github.com/paradisec-archive/nabu/issues/1168)).

No tests updated: paragest has no test runner covering the lambdas; verified with `pnpm run lint:types` and `pnpm run lint:biome`.