### PR TITLE
feat: send pipeline notes to nabu when creating/updating essences

### DIFF
--- a/src/common/add-to-catalog.ts
+++ b/src/common/add-to-catalog.ts
@@ -34,15 +34,12 @@ const upsertEssence = async (
   collectionIdentifier: string,
   itemIdentifier: string,
   filename: string,
-  size: number,
-  mimetype: string,
+  baseAttributes: { size: number; mimetype: string; ingestNotes: string },
   event: Event,
   extractedContent?: ExtractedContent,
 ) => {
-  const attributes = {
-    mimetype,
-    size,
-  };
+  const { mimetype } = baseAttributes;
+  const attributes = { ...baseAttributes };
 
   if (mimetype.startsWith('audio') || mimetype.startsWith('video')) {
     const { other: _other, rawFps: _rawFps, ...mediaAttributes } = await getMediaMetadata(getPath(`output/${filename}`), event);
@@ -94,6 +91,10 @@ export const handler = async (event: Event) => {
 
   const filenames = fs.readdirSync(dir);
 
+  // Snapshot before the per-file notes below so every essence stores the same
+  // provenance, free of catalog bookkeeping entries
+  const ingestNotes = notes.join('\n');
+
   const promises = filenames.map(async (filename) => {
     const extension = filename.split('.').pop();
     if (!extension) {
@@ -115,7 +116,7 @@ export const handler = async (event: Event) => {
 
     await upload(src, destBucket, dst, mimetype, ['wav', 'mkv'].includes(extension));
 
-    const created = await upsertEssence(collectionIdentifier, itemIdentifier, filename, size, mimetype, event, extractedContent);
+    const created = await upsertEssence(collectionIdentifier, itemIdentifier, filename, { size, mimetype, ingestNotes }, event, extractedContent);
 
     notes.push(`addMediaMetadata: ${created ? 'Created' : 'Updated'} essence`);
   });

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -11,6 +11,7 @@ export type EssenceAttributes = {
   duration?: number | null | undefined;
   extractedContent?: ExtractedContentInput | null | undefined;
   fps?: number | null | undefined;
+  ingestNotes?: string | null | undefined;
   mimetype: string;
   samplerate?: number | null | undefined;
   size: unknown;


### PR DESCRIPTION
## Summary

- Send the accumulated pipeline notes, newline-joined (the same rendering the ingest emails use), as the new `ingestNotes` essence attribute in the catalog upsert — on both the create and update paths (nabu overwrites on update, per spec)
- Regenerate GraphQL codegen types against the updated nabu schema so `ingestNotes` is compile-checked; the live schema at admin-catalog already includes the field (nabu#1175 / nabu#1176 deployed)
- Success and failure emails are unchanged and keep rendering the full notes

## Implementation note

The notes are snapshotted (`notes.join('\n')`) once before the per-file loop rather than inside each upsert. This keeps the stored provenance deterministic across the concurrently processed output files and excludes the per-file `addToCatalog: Uploading …` bookkeeping note as well as the post-upsert `addMediaMetadata` note — one note more than the spec explicitly accepted excluding, but consistent with its rationale that stored notes cover how the file was produced, not catalog bookkeeping. Flagging in case you'd rather include the upload note.

Known consideration (out of spec scope): `ingestNotes` has no client-side size cap, unlike `extractedContent`'s truncation seam — notes are dozens of short lines in practice, so no guard was added.

Closes #39

## Test plan

- [x] `pnpm lint:types` — clean
- [x] `pnpm exec biome check .` — clean
- [x] `pnpm lint:knip` — clean
- [x] `pnpm test` — 19/19 pass
- [ ] After merge/deploy: re-ingest a test file and confirm the essence in nabu shows the pipeline notes